### PR TITLE
feat(reordering): added move item API

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8
+// swift-tools-version: 5.7.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version: 5.8
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ Add/Insert/Delete - quick helper methods:
 addItems(items, itemChildren: { $0.subitems }, to: listTreeDataSource)
 ```
 
+Fold (inorder traversal + map into final result):
+Use case: changes were made and we need final tree. FO 
+```
+let folded = listTreeDataSource.fold(NodeTestItem.init) { item, subitems in
+    NodeTestItem(identifier: item.identifier, title: item.title, subitems: subitems)
+}
+
+Or Fold with Identity (when element already hierarchical item):
+let folded = sut.fold({ $0 }) { root, _ in root }
+```
+
 Add/Insert/Delete/Move - More grannular control:
 ```
 // Append:
@@ -63,8 +74,9 @@ listTreeDataSource.delete([itemToDelete])
 
 // Move:
 // E.g. user drags `existingNode` into `newParent` subitems with 0 index.
-// existingNode = listTreeDataSource.items[sourceIdx] 
+// existingNode = listTreeDataSource.items[sourceIdx];
 // newParent = listTreeDataSource.items[dropParentIdx];
+// toIndex = drop index in newParent;
 listTreeDataSource.move(existingNode, toIndex: 0, inParent: newParent)
 
 // NOTE: Reload data source at the end of changes.

--- a/README.md
+++ b/README.md
@@ -52,12 +52,7 @@ addItems(items, itemChildren: { $0.subitems }, to: listTreeDataSource)
 Fold (inorder traversal + map into final result):
 Use case: changes were made and we need final tree.
 ```
-let folded = listTreeDataSource.fold({ ResultItem(item: $0) }) { item, subitems in
-    ResultItem(identifier: item.identifier, title: item.title, subitems: subitems)
-}
-
-// Or Fold with Identity (when element already hierarchical item):
-let folded = sut.fold({ $0 }) { root, _ in root }
+let folded = listTreeDataSource.fold(ResultItem(leaf:), cons: ResultItem(item:children:))
 ```
 
 Add/Insert/Delete/Move - More grannular control:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Add/Insert/Delete - quick helper methods:
 addItems(items, itemChildren: { $0.subitems }, to: listTreeDataSource)
 ```
 
-Add/Insert/Delete - More grannular control:
+Add/Insert/Delete/Move - More grannular control:
 ```
 // Append:
 listTreeDataSource.append(currentToAdd, to: referenceParent)
@@ -58,6 +58,12 @@ listTreeDataSource.insert([insertionAfterItem], after: existingItem)
 
 // Delete:
 listTreeDataSource.delete([itemToDelete])
+
+// Move:
+// E.g. user drags `existingNode` into `newParent` subitems with 0 index.
+// existingNode = listTreeDataSource.items[sourceIdx] 
+// newParent = listTreeDataSource.items[dropParentIdx];
+listTreeDataSource.move(existingNode, toIndex: 0, inParent: newParent)
 
 // NOTE: Reload data source at the end of changes.
 listTreeDataSource.reload()

--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ addItems(items, itemChildren: { $0.subitems }, to: listTreeDataSource)
 Fold (inorder traversal + map into final result):
 Use case: changes were made and we need final tree. FO 
 ```
-let folded = listTreeDataSource.fold(NodeTestItem.init) { item, subitems in
-    NodeTestItem(identifier: item.identifier, title: item.title, subitems: subitems)
+let folded = listTreeDataSource.fold({ ResultItem(item: $0) }) { item, subitems in
+    ResultItem(identifier: item.identifier, title: item.title, subitems: subitems)
 }
 
-Or Fold with Identity (when element already hierarchical item):
+// Or Fold with Identity (when element already hierarchical item):
 let folded = sut.fold({ $0 }) { root, _ in root }
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ addItems(items, itemChildren: { $0.subitems }, to: listTreeDataSource)
 ```
 
 Fold (inorder traversal + map into final result):
-Use case: changes were made and we need final tree. FO 
+Use case: changes were made and we need final tree.
 ```
 let folded = listTreeDataSource.fold({ ResultItem(item: $0) }) { item, subitems in
     ResultItem(identifier: item.identifier, title: item.title, subitems: subitems)

--- a/Sources/SwiftListTreeDataSource/FilterableListTreeDataSource.swift
+++ b/Sources/SwiftListTreeDataSource/FilterableListTreeDataSource.swift
@@ -94,6 +94,10 @@ open class FilterableListTreeDataSource<ItemIdentifierType>: ListTreeDataSource<
         super.append(items, to: parent)
         needRebuildAllFlattenedItemStore = true
     }
+    public override func move(_ item: ItemIdentifierType, toIndex: Int, inParent: ItemIdentifierType?) {
+        super.move(item, toIndex: toIndex, inParent: inParent)
+        needRebuildAllFlattenedItemStore = true
+    }
     public override func insert(_ items: [ItemIdentifierType], after item: ItemIdentifierType) {
         super.insert(items, after: item)
         needRebuildAllFlattenedItemStore = true

--- a/Sources/SwiftListTreeDataSource/ListTreeDataSource.swift
+++ b/Sources/SwiftListTreeDataSource/ListTreeDataSource.swift
@@ -41,7 +41,19 @@ open class TreeItem<Item: Hashable>: Hashable, Identifiable {
         }
         return counter
     }
-    
+
+    public func fold<Result>(_ leaf: (Item) -> Result, cons: (Item, [Result]) -> Result) -> Result {
+        switch self.subitems {
+        case []:
+            return leaf(self.value)
+        case let nodes:
+            return cons(
+                self.value,
+                nodes.map { $0.fold(leaf, cons: cons) }
+            )
+        }
+    }
+
     public func allParents(of item: TreeItem<Item>) -> [TreeItem<Item>] {
         var parents: [TreeItem<Item>] = []
         var currentItem: TreeItem<Item> = item
@@ -89,7 +101,18 @@ open class ListTreeDataSource<ItemIdentifierType> where ItemIdentifierType : Has
     func setShownFlatItems(_ items: [TreeItemType]) {
         self.shownFlatItems = items
     }
-        
+
+    /// Folds created hierarchical store.
+    /// - Parameters:
+    ///   - leaf: The leaf case
+    ///   - cons: The cons case
+    /// - Returns: The folded hierarchical store.
+    public func fold<Result>(_ leaf: (ItemIdentifierType) -> Result, cons: (ItemIdentifierType, [Result]) -> Result) -> [Result] {
+        backingStore.map { node in
+            node.fold(leaf, cons: cons)
+        }
+    }
+
     /// Adds the array of `items` to specified `parent`.
     /// - Parameters:
     ///   - items: The array of items to add.

--- a/Tests/Shared/Helpers.swift
+++ b/Tests/Shared/Helpers.swift
@@ -4,7 +4,9 @@ import Foundation
 public func addItems(_ items: [OutlineItem], to snapshot: ListTreeDataSource<OutlineItem>) {
     addItems(items, itemChildren: { $0.subitems }, to: snapshot)
 }
-
+public func addItems(_ items: [NodeTestItem], to snapshot: ListTreeDataSource<NodeTestItem>) {
+    addItems(items, itemChildren: { $0.subitems }, to: snapshot)
+}
 public func depthFirstFlattened(items: [OutlineItem]) -> [OutlineItem] {
     return depthFirstFlattened(items: items, itemChildren: { $0.subitems })
 }

--- a/Tests/Shared/MockData.swift
+++ b/Tests/Shared/MockData.swift
@@ -5,7 +5,6 @@
 //  Created by Dzmitry Antonenka on 18.04.21.
 //
 
-import TestsShared
 import Foundation
 
 struct DataSet {
@@ -25,7 +24,21 @@ struct DataSet {
         // Total elements in tree: (Int) $R0 = 7_174_452, creation time ~17.5 sec on MBP 2019, core i7
         return menuItems(targetNestLevel: 14, currentLevel: 0, itemsInSection: 3)
     }()
-    
+
+    static var mockDataTiny: [OutlineItem] = {
+        var items: [OutlineItem] = [
+            OutlineItem(title: "Level 0, item1", subitems: [
+                OutlineItem(title: "Level 1, item1"),
+                OutlineItem(title: "Level 1, item2", subitems: [
+                    OutlineItem(title: "Level 2, item1"),
+                    OutlineItem(title: "Level 2, item2")
+                ])
+            ]),
+            OutlineItem(title: "Level 0, item2")
+        ]
+        return items
+    }()
+
     static var mockDataSmall: [OutlineItem] = {
         var items: [OutlineItem] = [
                 OutlineItem(title: "Compositional Layout", subitems: [
@@ -92,16 +105,17 @@ struct DataSet {
     }
 }
 
-
-enum MockData {
+public enum MockData {
+    case tiny
     case small
     case large88K
     case large350K
     case doubleLarge797K
     case extraLarge7_2M
-    
-    var items: [OutlineItem] {
+
+    public var items: [OutlineItem] {
         switch self {
+        case .tiny: return DataSet.mockDataTiny
         case .small: return DataSet.mockDataSmall
         case .large88K: return DataSet.mockData88K
         case .large350K: return DataSet.mockData350K
@@ -111,15 +125,16 @@ enum MockData {
     }
 }
 
-class DataManager {
-    static let shared = DataManager()
+public class DataManager {
+    public static let shared = DataManager()
         
-    var mockData: MockData { self.mockDataSmall }
+    public var mockData: MockData { self.mockDataSmall }
     
     // specialized data sets
-    lazy var mockDataSmall: MockData = .small
-    lazy var mockDataLarge88K: MockData = .large88K
-    lazy var mockDataLarge350K: MockData = .large350K
-    lazy var mockDataDoubleLarge797K: MockData = .doubleLarge797K
-    lazy var mockDataExtraLarge7_2M: MockData = .extraLarge7_2M
+    public lazy var mockDataTiny: MockData = .tiny
+    public lazy var mockDataSmall: MockData = .small
+    public lazy var mockDataLarge88K: MockData = .large88K
+    public lazy var mockDataLarge350K: MockData = .large350K
+    public lazy var mockDataDoubleLarge797K: MockData = .doubleLarge797K
+    public lazy var mockDataExtraLarge7_2M: MockData = .extraLarge7_2M
 }

--- a/Tests/Shared/Model.swift
+++ b/Tests/Shared/Model.swift
@@ -44,15 +44,21 @@ public struct NodeTestItem: Hashable {
     public let identifier: UUID
     public let title: String
     public var subitems: [NodeTestItem]
-    public init(identifier: UUID, title: String, subitems: [NodeTestItem]) {
+    public init(identifier: UUID, title: String, subitems: [NodeTestItem] = []) {
         self.identifier = identifier
         self.title = title
         self.subitems = subitems
     }
 }
 extension NodeTestItem {
+    public init(leaf: NodeTestItem) {
+        self.init(identifier: leaf.identifier, title: leaf.title, subitems: [])
+    }
     public init(_ item: NodeTestItem) {
         self.init(identifier: item.identifier, title: item.title, subitems: item.subitems)
+    }
+    public init(_ item: NodeTestItem, children: [NodeTestItem]) {
+        self.init(identifier: item.identifier, title: item.title, subitems: children)
     }
     public init(outline: OutlineItem) {
         identifier = outline.identifier

--- a/Tests/Shared/Model.swift
+++ b/Tests/Shared/Model.swift
@@ -1,21 +1,36 @@
 import Foundation
 
 public class OutlineItem: Hashable {
+    public let identifier: UUID
     public let title: String
     public var subitems: [OutlineItem]
 
-    public init(title: String,
-         subitems: [OutlineItem] = []) {
+    public init(
+        identifier: UUID = UUID(),
+        title: String,
+        subitems: [OutlineItem] = []
+    ) {
+        self.identifier = identifier
         self.title = title
         self.subitems = subitems
     }
+
+    public init(
+        other: OutlineItem
+    ) {
+        self.identifier = other.identifier
+        self.title = other.title
+        self.subitems = other.subitems
+    }
+
     public func hash(into hasher: inout Hasher) {
+        // don't add subitems recursively for performance reasons.
         hasher.combine(identifier)
     }
     public static func == (lhs: OutlineItem, rhs: OutlineItem) -> Bool {
-        return lhs.identifier == rhs.identifier
+        // don't add subitems recursively for performance reasons.
+        lhs.identifier == rhs.identifier
     }
-    private let identifier = UUID()
 }
 
 extension OutlineItem: CustomStringConvertible {
@@ -23,4 +38,25 @@ extension OutlineItem: CustomStringConvertible {
 }
 extension OutlineItem: CustomDebugStringConvertible {
     public var debugDescription: String { "\(title)" }
+}
+
+public struct NodeTestItem: Hashable {
+    public let identifier: UUID
+    public let title: String
+    public var subitems: [NodeTestItem]
+    public init(identifier: UUID, title: String, subitems: [NodeTestItem]) {
+        self.identifier = identifier
+        self.title = title
+        self.subitems = subitems
+    }
+}
+extension NodeTestItem {
+    public init(_ item: NodeTestItem) {
+        self.init(identifier: item.identifier, title: item.title, subitems: item.subitems)
+    }
+    public init(outline: OutlineItem) {
+        identifier = outline.identifier
+        title = outline.title
+        subitems = outline.subitems.map { NodeTestItem(outline: $0) }
+    }
 }

--- a/Tests/SwiftListTreeDataSourceTests/DebugDescriptionUtilsTests.swift
+++ b/Tests/SwiftListTreeDataSourceTests/DebugDescriptionUtilsTests.swift
@@ -110,18 +110,9 @@ class DebugDescriptionUtilsTests: XCTestCase {
     // MARK: - Helpers
     
     func tinyHardcodedDataset() -> [OutlineItem] {
-        return [
-            OutlineItem(title: "Level 0, item1", subitems: [
-                OutlineItem(title: "Level 1, item1"),
-                OutlineItem(title: "Level 1, item2", subitems: [
-                    OutlineItem(title: "Level 2, item1"),
-                    OutlineItem(title: "Level 2, item2")
-                ])
-            ]),
-            OutlineItem(title: "Level 0, item2")
-        ]
+        DataManager.shared.mockDataTiny.items
     }
-    
+
     func verifyExpandedLevelsDescriptionsMatchesTopLevelForFlattenedItems() {
         let backingStoreExpandedLevelsDescription = debugDescriptionExpandedLevels(sut.backingStore)
         let flattenedItemsTopLevelsDescription = debugDescriptionTopLevel(sut.items)

--- a/Tests/SwiftListTreeDataSourceTests/ListTreeDataSource+BasicTests.swift
+++ b/Tests/SwiftListTreeDataSourceTests/ListTreeDataSource+BasicTests.swift
@@ -24,8 +24,32 @@ class ListTreeDataSourceTests: XCTestCase {
     func setUpSut() {
         sut = ListTreeDataSource<OutlineItem>()
     }
-    
-    // MARK: - Append/Insert/Delete tests
+
+    func test_foldRecreate_withTinyDataSet_shouldMatchIdentity() {
+        let sut = ListTreeDataSource<NodeTestItem>()
+
+        let dataSet = DataManager.shared.mockDataTiny.items.map(NodeTestItem.init(outline:))
+        addItems(dataSet, to: sut)
+        sut.reload()
+
+        let folded = sut.fold(NodeTestItem.init) { item, subitems in
+            NodeTestItem(identifier: item.identifier, title: item.title, subitems: subitems)
+        }
+        XCTAssertEqual(dataSet, folded)
+    }
+
+    func test_foldId_withTinyDataSet_shouldMatchIdentity() {
+        let sut = ListTreeDataSource<NodeTestItem>()
+
+        let dataSet = DataManager.shared.mockDataTiny.items.map(NodeTestItem.init(outline:))
+        addItems(dataSet, to: sut)
+        sut.reload()
+
+        let folded = sut.fold(id(_:)) { root, _ in root }
+        XCTAssertEqual(dataSet, folded)
+    }
+
+    // MARK: - Append/Insert/Delete/Move tests
     
     func test_append_withOneElementToNilParent_shouldAppendAsHead() throws {
         sut = ListTreeDataSource<OutlineItem>() // start from clean state
@@ -459,4 +483,4 @@ class ListTreeDataSourceTests: XCTestCase {
     }
 }
 
-
+func id<A>(_ a: A) -> A { a }


### PR DESCRIPTION
Introduced API for moving/reordering items:

`func move(_ item: ItemIdentifierType, toIndex: Int, inParent newParent: ItemIdentifierType?)`

Please see `Tests/SwiftListTreeDataSourceTests/ListTreeDataSource+BasicTests.swift` for use cases.

